### PR TITLE
Disable delay on Frontend

### DIFF
--- a/src/frontend/handlers.go
+++ b/src/frontend/handlers.go
@@ -75,7 +75,7 @@ func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
 	// introducing a random delay for AIOps - Faulty Deployment RCA
 	// TODO: Make this into a feature flag later
 	// 
-	time.Sleep(time.Duration(rand.Int31n(30)) * time.Second);
+	// time.Sleep(time.Duration(rand.Int31n(30)) * time.Second); -- commented out for now - not needed for DASH 2024
 
 	type productView struct {
 		Item  *pb.Product

--- a/src/paymentservice/src/main/resources/logback.xml
+++ b/src/paymentservice/src/main/resources/logback.xml
@@ -1,13 +1,19 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-      <immediateFlush>true</immediateFlush>
-  
-      <encoder>
-        <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %X{dd.trace_id} %X{dd.span_id} - %m%n</pattern>
-      </encoder>
-    </appender>
-  
-    <root level="DEBUG">
-      <appender-ref ref="STDOUT"/>
-    </root>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <immediateFlush>true</immediateFlush>
+
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %X{dd.trace_id} %X{dd.span_id} - %m%n</pattern>
+    </encoder>
+  </appender>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>logs/app.log</file>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+  </appender>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT"/>
+  </root>
+  <root level="INFO">
+  <appender-ref ref="FILE"/>
+  </root>
   </configuration>


### PR DESCRIPTION
Update the handlers.go to disable the  random delay as it is not part of the DASH 2024 challenges. See this Slack: https://dd.slack.com/archives/C0780M3AEBC/p1718298770040169