### PR TITLE
Adding More Logs to adservice for pretty Log Patterns

### DIFF
--- a/ctf/datadog-values.yaml
+++ b/ctf/datadog-values.yaml
@@ -43,6 +43,8 @@ datadog:
   logs:
     enabled: true
     containerCollectAll: true
+  logs_config:
+    auto_multi_line_detection: true
 
   ## Collect kubernetes events
   collectEvents: true

--- a/src/adservice/src/main/java/hipstershop/AdService.java
+++ b/src/adservice/src/main/java/hipstershop/AdService.java
@@ -173,21 +173,22 @@ public final class AdService {
     logger.debug("Ad selected. Advertiser '" + advertiser + "'");
     //Let's create interesting error logs here
     if (adid < 20) { //we are generating an error log for 20% of the requests
-        log.error("Unable to display ad id " + adid);
+        logger.error("Unable to display ad id " + adid);
         //We will generate 3 more different error patterns
         if (adid < 10){
-            log.error("Ad id " + adid + " has malformed JSON in line " + adid * 2 );
+            logger.error("Ad id " + adid + " has malformed JSON in line " + adid * 2 );
         } else if (adid < 14){
-            log.error("Unable to connect to the ad network for advertiser '" + advertiser + "'");
+            logger.error("Unable to connect to the ad network for advertiser '" + advertiser + "'");
         } else if (adid < 17){
-            log.error("Unknown ad id " + adid);
+            logger.error("Unknown ad id " + adid);
         } else {
-            log.error("Invalid combination. Advertiser: '" + advertiser + "' Ad id: " + adid);
+            logger.error("Invalid combination. Advertiser: '" + advertiser + "' Ad id: " + adid);
         }
-   } else {
+    } else {
         //ad impression
         logger.info("Ad seen. Advertiser '" + advertiser + "'");
-   }
+    }
+  }
 
   private static AdService getInstance() {
     return service;

--- a/src/adservice/src/main/java/hipstershop/AdService.java
+++ b/src/adservice/src/main/java/hipstershop/AdService.java
@@ -146,6 +146,7 @@ public final class AdService {
     String advertiser;
     int time = (int) (new Date().getTime()/1000L) % 300; // 5 minute repeating schedule
     int rand = random.nextInt(10);
+    int adid = random.nextInt(100);
     
 
     if (time < 15) {
@@ -168,12 +169,25 @@ public final class AdService {
     } else { //40% of the time
         advertiser = advertisers[0];
     }
-    //TODO: remove this line after we are done tweaking.
-    logger.info("Time: " + time + " Rand: " + rand);
 
-    //ad impression
-    logger.info("Ad seen. Advertiser '" + advertiser + "'");
-  }
+    logger.debug("Ad selected. Advertiser '" + advertiser + "'");
+    //Let's create interesting error logs here
+    if (adid < 20) { //we are generating an error log for 20% of the requests
+        log.error("Unable to display ad id " + adid);
+        //We will generate 3 more different error patterns
+        if (adid < 10){
+            log.error("Ad id " + adid + " has malformed JSON in line " + adid * 2 );
+        } else if (adid < 14){
+            log.error("Unable to connect to the ad network for advertiser '" + advertiser + "'");
+        } else if (adid < 17){
+            log.error("Unknown ad id " + adid);
+        } else {
+            log.error("Invalid combination. Advertiser: '" + advertiser + "' Ad id: " + adid);
+        }
+   } else {
+        //ad impression
+        logger.info("Ad seen. Advertiser '" + advertiser + "'");
+   }
 
   private static AdService getInstance() {
     return service;


### PR DESCRIPTION
### Background 
<!-- What was happening before this PR, and the problem(s) it solves -->
I noticed that there were not enough different types of error logs in the tsre-microservices to do a good logs demo. Now the standard logs part of the 3 pillar demo works well.
### Fixes 
<!-- Link the issue(s) this PR fixes-->
### Change Summary
<!-- Short summary of the changes submitted -->
I used service adservice, which already has advertising logs, but added several different patterns, recording these logs with the error status to demonstrate log search facets.

### Additional Notes
<!-- Any remaining concerns -->
While I was there I fixed agent config for multiline logs, which were not aggregated correctly for java traces, which I spotted.

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->
My newest workshop [Interactive Demo Training](https://play.instruqt.com/datadog-partner-solutions/invite/emvlm0cogjyk), uses this version of the app. Go through the Logs  and Monitors section of the lab to see the produced effect.

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
